### PR TITLE
Support pkg/errors generated stack traces.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,15 @@
 package roll
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 // -- Test helpers
@@ -17,9 +22,29 @@ func (e *CustomError) Error() string {
 	return e.s
 }
 
-func setup() {
+func setup() func() {
 	Token = os.Getenv("TOKEN")
 	Environment = "test"
+
+	if Token == "" {
+		Token = "test"
+		originalEndpoint := DefaultEndpoint
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`{"result": {"uuid": "01234567890123456789012345678901"}}`))
+			},
+		))
+
+		DefaultEndpoint = server.URL
+
+		return func() {
+			DefaultEndpoint = originalEndpoint
+			server.Close()
+		}
+	}
+
+	// Assume Token was provided and we want integration tests.
+	return func() {}
 }
 
 // -- Tests
@@ -38,7 +63,9 @@ func TestErrorClass(t *testing.T) {
 }
 
 func TestCritical(t *testing.T) {
-	setup()
+	teardown := setup()
+	defer teardown()
+
 	uuid, err := Critical(errors.New("global critical"), map[string]string{"extras": "true"})
 	if err != nil {
 		t.Error(err)
@@ -49,7 +76,9 @@ func TestCritical(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	setup()
+	teardown := setup()
+	defer teardown()
+
 	uuid, err := Error(errors.New("global error"), map[string]string{"extras": "true"})
 	if err != nil {
 		t.Error(err)
@@ -60,7 +89,9 @@ func TestError(t *testing.T) {
 }
 
 func TestWarning(t *testing.T) {
-	setup()
+	teardown := setup()
+	defer teardown()
+
 	uuid, err := Warning(errors.New("global warning"), map[string]string{"extras": "true"})
 	if err != nil {
 		t.Error(err)
@@ -71,7 +102,9 @@ func TestWarning(t *testing.T) {
 }
 
 func TestInfo(t *testing.T) {
-	setup()
+	teardown := setup()
+	defer teardown()
+
 	uuid, err := Info("global info", map[string]string{"extras": "true"})
 	if err != nil {
 		t.Error(err)
@@ -82,7 +115,9 @@ func TestInfo(t *testing.T) {
 }
 
 func TestDebug(t *testing.T) {
-	setup()
+	teardown := setup()
+	defer teardown()
+
 	uuid, err := Debug("global debug", map[string]string{"extras": "true"})
 	if err != nil {
 		t.Error(err)
@@ -93,7 +128,10 @@ func TestDebug(t *testing.T) {
 }
 
 func TestRollbarClientCritical(t *testing.T) {
-	client := New(os.Getenv("TOKEN"), "test")
+	teardown := setup()
+	defer teardown()
+
+	client := New(Token, Environment)
 
 	uuid, err := client.Critical(errors.New("new client critical"), map[string]string{"extras": "true"})
 	if err != nil {
@@ -105,7 +143,10 @@ func TestRollbarClientCritical(t *testing.T) {
 }
 
 func TestRollbarClientError(t *testing.T) {
-	client := New(os.Getenv("TOKEN"), "test")
+	teardown := setup()
+	defer teardown()
+
+	client := New(Token, Environment)
 
 	uuid, err := client.Error(errors.New("new client error"), map[string]string{"extras": "true"})
 	if err != nil {
@@ -117,7 +158,10 @@ func TestRollbarClientError(t *testing.T) {
 }
 
 func TestRollbarClientWarning(t *testing.T) {
-	client := New(os.Getenv("TOKEN"), "test")
+	teardown := setup()
+	defer teardown()
+
+	client := New(Token, Environment)
 
 	uuid, err := client.Warning(errors.New("new client warning"), map[string]string{"extras": "true"})
 	if err != nil {
@@ -129,7 +173,10 @@ func TestRollbarClientWarning(t *testing.T) {
 }
 
 func TestRollbarClientInfo(t *testing.T) {
-	client := New(os.Getenv("TOKEN"), "test")
+	teardown := setup()
+	defer teardown()
+
+	client := New(Token, Environment)
 
 	uuid, err := client.Info("new client info", map[string]string{"extras": "true"})
 	if err != nil {
@@ -141,7 +188,10 @@ func TestRollbarClientInfo(t *testing.T) {
 }
 
 func TestRollbarClientDebug(t *testing.T) {
-	client := New(os.Getenv("TOKEN"), "test")
+	teardown := setup()
+	defer teardown()
+
+	client := New(Token, Environment)
 
 	uuid, err := client.Debug("new client debug", map[string]string{"extras": "true"})
 	if err != nil {
@@ -149,5 +199,33 @@ func TestRollbarClientDebug(t *testing.T) {
 	}
 	if len(uuid) != 32 {
 		t.Errorf("expected UUID, got: %#v", uuid)
+	}
+}
+
+func TestAssembleStackWrapped(t *testing.T) {
+	err := errors.Wrap(errors.New("foo bar"), "fooing bar")
+	client := &rollbarClient{}
+	item := client.assembleStack(ERR, err, 3, nil)
+	body, jerr := json.Marshal(item)
+	if jerr != nil {
+		t.Fatalf("error while marshaling to json: %q", jerr)
+	}
+
+	if !strings.Contains(string(body), "TestAssembleStackWrapped") {
+		t.Errorf("expected TestAssembleStackWrapped in frames, but was not found.")
+	}
+}
+
+func TestAssembleStackNormal(t *testing.T) {
+	err := fmt.Errorf("foo bar")
+	client := &rollbarClient{}
+	item := client.assembleStack(ERR, err, 3, nil)
+	body, jerr := json.Marshal(item)
+	if jerr != nil {
+		t.Fatalf("error while marshaling to json: %q", jerr)
+	}
+
+	if strings.Contains(string(body), "TestAssembleStackNormal") {
+		t.Errorf("expected TestAssembleStackNormal to not be found in frames, but was.")
 	}
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,18 +1,21 @@
 package roll
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestBuildStack(t *testing.T) {
 	frame := buildStack(1)[0]
-	if frame.Filename != "github.com/stvp/roll/stack_test.go" {
+	if !strings.HasSuffix(frame.Filename, "/roll/stack_test.go") {
 		t.Errorf("got: %s", frame.Filename)
 	}
 	if frame.Method != "roll.TestBuildStack" {
 		t.Errorf("got: %s", frame.Method)
 	}
-	if frame.Line != 8 {
+	if frame.Line != 11 {
 		t.Errorf("got: %d", frame.Line)
 	}
 }
@@ -77,5 +80,25 @@ func TestShortenFilePath(t *testing.T) {
 		if got != test.Expected {
 			t.Errorf("tests[%d]: got %s", i, got)
 		}
+	}
+}
+
+func TestUnwrapStack(t *testing.T) {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	err, ok := errors.Wrap(errors.New("foo bar"), "fooing bar").(stackTracer)
+	if !ok {
+		t.Fatalf("errors.Wrap didn't return a stackTracer!")
+	}
+
+	s := unwrapStack(err.StackTrace())
+	if len(s) != 3 {
+		t.Errorf("Expected 3 frames, got %d", len(s))
+	} else if !strings.HasSuffix(s[0].Filename, "stack_test.go") {
+		t.Errorf("Expected first frame to be contained in stack_test.go, found %q instead", s[0].Filename)
+	} else if !strings.HasSuffix(s[0].Method, "TestUnwrapStack") {
+		t.Errorf("Expected first frame to contain method TestUnwrapStack, found %q instead", s[0].Method)
 	}
 }


### PR DESCRIPTION
- If reported error is a stackTracer, as defined by pkg/errors, generate
  the stack trace from it, instead.
- Allow for unittesting of tests, by making TOKEN not required.
