### PR TITLE
Do not use title to determine fingerprint

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -63,7 +63,6 @@ func buildRollbarFrames(callers []uintptr) (frames rollbarFrames) {
 // filename, method name, and line number of every frame in the stack.
 func (f rollbarFrames) fingerprint(title string) string {
 	hash := crc32.NewIEEE()
-	fmt.Fprintf(hash, "%s", title)
 	for _, frame := range f {
 		fmt.Fprintf(hash, "%s%s%d", frame.Filename, frame.Method, frame.Line)
 	}

--- a/stack_test.go
+++ b/stack_test.go
@@ -28,28 +28,28 @@ func TestRollbarFramesFingerprint(t *testing.T) {
 		Frames      rollbarFrames
 	}{
 		{
-			"c9dfdc0e",
+			"9344290d",
 			"broken",
 			rollbarFrames{
 				{"foo.go", "Oops", 1},
 			},
 		},
 		{
-			"21037bf5",
+			"9344290d",
 			"very broken",
 			rollbarFrames{
 				{"foo.go", "Oops", 1},
 			},
 		},
 		{
-			"50d68db4",
+			"a4d78b7",
 			"broken",
 			rollbarFrames{
 				{"foo.go", "Oops", 2},
 			},
 		},
 		{
-			"b341ee82",
+			"50e0fcb3",
 			"broken",
 			rollbarFrames{
 				{"foo.go", "Oops", 1},


### PR DESCRIPTION
As it was, if an error contained a different string, even though it was
from the same source, the fingerprint would be different and the errors
would not be grouped in Rollbar. Now we guarantee that the hash is
always the same for the same filename, method name, and line number.
